### PR TITLE
fixes for Django 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,14 @@ env:
   - DJANGO="django>=1.8,<1.9"
   - DJANGO="django>=1.10,<1.11"
   - DJANGO="django>=1.11,<1.12"
+  - DJANGO="django>=2.0,<2.1"
 matrix:
   exclude:
     - python: 3.5
       env: DJANGO="django>=1.7,<1.8"
+  exclude:
+    - python: 2.7
+      env: DJANGO="django>=2.0,<2.1"
 install:
   - pip install $DJANGO
   - pip install -r requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     url='https://git.csx.cam.ac.uk/x/ucs/raven/django-ucamwebauth.git',
     # When changing this version number, remember to update
     # django-ucamwebauth.spec and debian/changelog.
-    version='1.4.4',
+    version='1.4.5',
     license='MIT',
     author='Information Systems Group, University Information Services, University of Cambridge',
     author_email='raven-support@cam.ac.uk',

--- a/ucamwebauth/migrations/0001_initial.py
+++ b/ucamwebauth/migrations/0001_initial.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(serialize=False, auto_created=True, primary_key=True, verbose_name='ID')),
                 ('raven_for_life', models.BooleanField(default=False)),
-                ('user', models.OneToOneField(related_name='profile', to=settings.AUTH_USER_MODEL)),
+                ('user', models.OneToOneField(related_name='profile', to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
             ],
         ),
     ]

--- a/ucamwebauth/utils.py
+++ b/ucamwebauth/utils.py
@@ -8,7 +8,10 @@ except ImportError:
     from urllib.parse import parse_qs, unquote
 from django.conf import settings
 from django.http import HttpResponseRedirect
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from ucamwebauth.exceptions import MalformedResponseError
 
 


### PR DESCRIPTION
* django.core.urlresolvers has been deprecated since 1.10 and has been
removed in Django 2.0. Fix this import error.
* The migration does not specify an on_delete parameter in a foreign key. This is now required.