### PR TITLE
Future drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ UCAMWEBAUTH_TIMEOUT: An integer with the time (in seconds) that has to pass to c
 UCAMWEBAUTH_REDIRECT_AFTER_LOGIN: The url where you want to redirect the user after login (Default to '/').
 UCAMWEBAUTH_CREATE_USE: This defaults to True, allowing the autocreation of users who have been successfully 
 authenticated by Raven, but do not exist in the local database. The user is created with set_unusable_password().
-UCAMWEBAUTH_NTPDRIFT: Defaults to 0, the number of milliseconds that you may allow the client to drift into the future, when the client machine may have drifted out of sync with ntp (found during Django app development).
+UCAMWEBAUTH_NTPDRIFT: Defaults to 0, the number of milliseconds you may allow the client to drift (lag its ntp service). Observed during Django app development.
 ```
 
 An example, referencing the Raven test environment is given below:

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ UCAMWEBAUTH_TIMEOUT: An integer with the time (in seconds) that has to pass to c
 UCAMWEBAUTH_REDIRECT_AFTER_LOGIN: The url where you want to redirect the user after login (Default to '/').
 UCAMWEBAUTH_CREATE_USE: This defaults to True, allowing the autocreation of users who have been successfully 
 authenticated by Raven, but do not exist in the local database. The user is created with set_unusable_password().
+UCAMWEBAUTH_NTPDRIFT: Defaults to 0, the number of milliseconds that you may allow the client to drift into the future, when the client machine may have drifted out of sync with ntp (found during Django app development).
 ```
 
 An example, referencing the Raven test environment is given below:

--- a/ucamwebauth/__init__.py
+++ b/ucamwebauth/__init__.py
@@ -92,7 +92,7 @@ class RavenResponse(object):
         # have their clocks synchronised by NTP or a similar mechanism. Providing the WAA has access to an
         # NTP-synchronised clock then allowing for a transmission time of 30-60 seconds is probably appropriate.
         # Otherwise allowance must be made for the maximum expected clock skew.
-        if self.issue > time.time():
+        if self.issue > time.time()+1000000:
             raise InvalidResponseError("The timestamp on the response is in the future")
         if self.issue < time.time() - setting('UCAMWEBAUTH_TIMEOUT', 30):
             raise InvalidResponseError("Response has timed out - issued %s, now %s" %

--- a/ucamwebauth/__init__.py
+++ b/ucamwebauth/__init__.py
@@ -93,7 +93,7 @@ class RavenResponse(object):
         # NTP-synchronised clock then allowing for a transmission time of 30-60 seconds is probably appropriate.
         # Otherwise allowance must be made for the maximum expected clock skew.
         if self.issue > time.time()+0.001*setting('UCAMWEBAUTH_TSDRIFT', 0):
-            raise InvalidResponseError("The timestamp on the response appears in the future (configure UCAMWEBAUTH_TSDRIFT?)")
+            raise InvalidResponseError("The timestamp on the response appears in the future")
         if self.issue < time.time() - setting('UCAMWEBAUTH_TIMEOUT', 30):
             raise InvalidResponseError("Response has timed out - issued %s, now %s" %
                                        (time.asctime(time.gmtime(self.issue)), time.asctime()))

--- a/ucamwebauth/__init__.py
+++ b/ucamwebauth/__init__.py
@@ -92,7 +92,7 @@ class RavenResponse(object):
         # have their clocks synchronised by NTP or a similar mechanism. Providing the WAA has access to an
         # NTP-synchronised clock then allowing for a transmission time of 30-60 seconds is probably appropriate.
         # Otherwise allowance must be made for the maximum expected clock skew.
-        if self.issue > time.replace+0.001*setting('UCAMWEBAUTH_TSDRIFT', 0).time():
+        if self.issue > time.time()+0.001*setting('UCAMWEBAUTH_TSDRIFT', 0).time():
             raise InvalidResponseError("The timestamp on the response appears in the future (configure UCAMWEBAUTH_TSDRIFT?)")
         if self.issue < time.time() - setting('UCAMWEBAUTH_TIMEOUT', 30):
             raise InvalidResponseError("Response has timed out - issued %s, now %s" %

--- a/ucamwebauth/__init__.py
+++ b/ucamwebauth/__init__.py
@@ -93,7 +93,7 @@ class RavenResponse(object):
         # NTP-synchronised clock then allowing for a transmission time of 30-60 seconds is probably appropriate.
         # Otherwise allowance must be made for the maximum expected clock skew.
         if self.issue > time.time()+0.001*setting('UCAMWEBAUTH_TSDRIFT', 0):
-            raise InvalidResponseError("The timestamp on the response appears in the future")
+            raise InvalidResponseError("The timestamp on the response is in the future")
         if self.issue < time.time() - setting('UCAMWEBAUTH_TIMEOUT', 30):
             raise InvalidResponseError("Response has timed out - issued %s, now %s" %
                                        (time.asctime(time.gmtime(self.issue)), time.asctime()))

--- a/ucamwebauth/__init__.py
+++ b/ucamwebauth/__init__.py
@@ -92,8 +92,8 @@ class RavenResponse(object):
         # have their clocks synchronised by NTP or a similar mechanism. Providing the WAA has access to an
         # NTP-synchronised clock then allowing for a transmission time of 30-60 seconds is probably appropriate.
         # Otherwise allowance must be made for the maximum expected clock skew.
-        if self.issue > time.time()+1000000:
-            raise InvalidResponseError("The timestamp on the response is in the future")
+        if self.issue > time.replace+0.001*setting('UCAMWEBAUTH_TSDRIFT', 0).time():
+            raise InvalidResponseError("The timestamp on the response appears in the future (configure UCAMWEBAUTH_TSDRIFT?)")
         if self.issue < time.time() - setting('UCAMWEBAUTH_TIMEOUT', 30):
             raise InvalidResponseError("Response has timed out - issued %s, now %s" %
                                        (time.asctime(time.gmtime(self.issue)), time.asctime()))

--- a/ucamwebauth/__init__.py
+++ b/ucamwebauth/__init__.py
@@ -92,7 +92,7 @@ class RavenResponse(object):
         # have their clocks synchronised by NTP or a similar mechanism. Providing the WAA has access to an
         # NTP-synchronised clock then allowing for a transmission time of 30-60 seconds is probably appropriate.
         # Otherwise allowance must be made for the maximum expected clock skew.
-        if self.issue > time.time()+0.001*setting('UCAMWEBAUTH_TSDRIFT', 0).time():
+        if self.issue > time.time()+0.001*setting('UCAMWEBAUTH_TSDRIFT', 0):
             raise InvalidResponseError("The timestamp on the response appears in the future (configure UCAMWEBAUTH_TSDRIFT?)")
         if self.issue < time.time() - setting('UCAMWEBAUTH_TIMEOUT', 30):
             raise InvalidResponseError("Response has timed out - issued %s, now %s" %

--- a/ucamwebauth/__init__.py
+++ b/ucamwebauth/__init__.py
@@ -92,7 +92,7 @@ class RavenResponse(object):
         # have their clocks synchronised by NTP or a similar mechanism. Providing the WAA has access to an
         # NTP-synchronised clock then allowing for a transmission time of 30-60 seconds is probably appropriate.
         # Otherwise allowance must be made for the maximum expected clock skew.
-        if self.issue > time.time()+0.001*setting('UCAMWEBAUTH_TSDRIFT', 0):
+        if self.issue > time.time()+0.001*setting('UCAMWEBAUTH_NTPDRIFT', 0):
             raise InvalidResponseError("The timestamp on the response is in the future")
         if self.issue < time.time() - setting('UCAMWEBAUTH_TIMEOUT', 30):
             raise InvalidResponseError("Response has timed out - issued %s, now %s" %

--- a/ucamwebauth/tests.py
+++ b/ucamwebauth/tests.py
@@ -178,6 +178,15 @@ class RavenTestCase(TestCase):
         self.assertEqual(str(excep.exception), 'The timestamp on the response is in the future')
         self.assertNotIn('_auth_user_id', self.client.session)
 
+    def test_login_issue_future_managed(self):
+        """Tests that a Raven response issued in the future can be managed by config option"""
+        with self.settings(UCAMWEBAUTH_CREATE_USER=False,UCAMWEBAUTH_TSDRIFT=62000):
+            self.client.get(reverse('raven_return'), 
+                            {'WLS-Response': create_wls_response(
+                                raven_issue=(datetime.utcnow() + timedelta(minutes=1)).strftime('%Y%m%dT%H%M%SZ')
+                            )})
+        self.assertIn('_auth_user_id', self.client.session)
+
     def test_wrong_status_code(self):
         with self.assertRaises(InvalidResponseError) as excep:
             self.client.get(reverse('raven_return'), {'WLS-Response': create_wls_response(raven_status='100')})

--- a/ucamwebauth/tests.py
+++ b/ucamwebauth/tests.py
@@ -183,7 +183,7 @@ class RavenTestCase(TestCase):
         with self.settings(UCAMWEBAUTH_CREATE_USER=False,UCAMWEBAUTH_TSDRIFT=62000):
             self.client.get(reverse('raven_return'), 
                             {'WLS-Response': create_wls_response(
-                                raven_issue=(datetime.utcnow() + timedelta(minutes=1)).strftime('%Y%m%dT%H%M%SZ')
+                                raven_issue=(datetime.utcnow() + timedelta(hours=1)).strftime('%Y%m%dT%H%M%SZ')
                             )})
         self.assertIn('_auth_user_id', self.client.session)
 

--- a/ucamwebauth/tests.py
+++ b/ucamwebauth/tests.py
@@ -180,10 +180,10 @@ class RavenTestCase(TestCase):
 
     def test_login_issue_future_managed(self):
         """Tests that a Raven response issued in the future can be managed by config option"""
-        with self.settings(UCAMWEBAUTH_CREATE_USER=False,UCAMWEBAUTH_TSDRIFT=62000):
+        with self.settings(UCAMWEBAUTH_CREATE_USER=False,UCAMWEBAUTH_NTPDRIFT=62000):
             self.client.get(reverse('raven_return'), 
                             {'WLS-Response': create_wls_response(
-                                raven_issue=(datetime.utcnow() + timedelta(hours=1)).strftime('%Y%m%dT%H%M%SZ')
+                                raven_issue=(datetime.utcnow() + timedelta(minutes=1)).strftime('%Y%m%dT%H%M%SZ')
                             )})
         self.assertIn('_auth_user_id', self.client.session)
 


### PR DESCRIPTION
During Django app development I occasionally have to manually trigger my windows client to NTP synchronise following a 'request in the future' response from the development raven service. Having spoken to other django developers within UCam this seems to be the case for others too.

The process to manually synchronise is quite frustrating (Windows), so I would like to propose an extra, optional, config variable UCAMWEBAUTH_NTPDRIFT which allows the admin to set the number of milliseconds it will allow a response to be appear in the 'future'.


